### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe jQuery plugin

### DIFF
--- a/assets/js/plugins/jquery.magnific-popup.js
+++ b/assets/js/plugins/jquery.magnific-popup.js
@@ -505,10 +505,17 @@
         // allows to modify markup
         _mfpTrigger('FirstMarkupParse', markup);
 
-        if(markup) {
+        var isSafeMarkup = !!markup;
+        if(isSafeMarkup && typeof markup === 'string') {
+          // Prevent unsafe option-driven HTML from being interpreted by jQuery
+          // (script tags, inline event handlers, javascript: URLs)
+          isSafeMarkup = !(/<\s*script\b/i.test(markup) || /\bon[a-z]+\s*=/i.test(markup) || /javascript\s*:/i.test(markup));
+        }
+
+        if(isSafeMarkup) {
           mfp.currTemplate[type] = $(markup);
         } else {
-          // if there is no markup found we just define that template is parsed
+          // if there is no safe markup found we just define that template is parsed
           mfp.currTemplate[type] = true;
         }
       }


### PR DESCRIPTION
Potential fix for [https://github.com/UF-CoDyMo-Lab/UF-CoDyMo-Lab.github.io/security/code-scanning/3](https://github.com/UF-CoDyMo-Lab/UF-CoDyMo-Lab.github.io/security/code-scanning/3)

Best fix: prevent unsafe HTML strings from being passed into jQuery HTML parsing at line 509, while preserving existing behavior for trusted/prebuilt templates. In this file, add a small validation gate before `$(markup)` that only allows markup values that are jQuery/DOM objects or strings that do **not** contain obviously dangerous executable constructs (`<script`, inline event handlers like `on...=`, and `javascript:` URLs). If validation fails, abort template parsing for that type by setting `mfp.currTemplate[type] = true` (same fallback semantics already used when no markup exists), avoiding unsafe DOM construction.

Concretely in `assets/js/plugins/jquery.magnific-popup.js`:
- Edit the block around lines 502–513.
- Introduce an `isSafeMarkup` check in that block.
- Only call `$(markup)` when safe; otherwise mark template as parsed without injecting.
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
